### PR TITLE
Added counter when new slice is created

### DIFF
--- a/tiles/alg/TILES.py
+++ b/tiles/alg/TILES.py
@@ -102,6 +102,7 @@ class TILES(object):
 
             if dif >= self.obs:
                 last_break = dt
+                self.added -= 1
 
                 print("New slice. Starting Day: %s" % dt)
 
@@ -110,7 +111,7 @@ class TILES(object):
                                    str(time.asctime(time.localtime(time.time())))))
 
                 self.status.write(u"Edge Added: %d\tEdge removed: %d\n" % (self.added, self.removed))
-                self.added = 0
+                self.added = 1
                 self.removed = 0
 
                 actual_time = dt

--- a/tiles/alg/eTILES.py
+++ b/tiles/alg/eTILES.py
@@ -84,6 +84,7 @@ class eTILES(TILES):
 
             if dif >= self.obs:
                 last_break = dt
+                self.added -= 1
 
                 print("New slice. Starting Day: %s" % dt)
 
@@ -92,7 +93,7 @@ class eTILES(TILES):
                                    str(time.asctime(time.localtime(time.time())))))
 
                 self.status.write(u"Edge Added: %d\tEdge removed: %d\n" % (self.added, self.removed))
-                self.added = 0
+                self.added = 1
                 self.removed = 0
 
                 actual_time = dt


### PR DESCRIPTION
When a new slice is created, the latest added edge should be counted for the new slice, not the previous one.